### PR TITLE
Getter and Setter added for naive property

### DIFF
--- a/lib/dom-scheduler.js
+++ b/lib/dom-scheduler.js
@@ -36,6 +36,14 @@
 
   scheduler.prototype = {
 
+    get naive() {
+      return naive;
+    },
+
+    set naive(value) {
+      naive = value;
+    },
+
     // *Direct* blocks should be used for direct manipulation use cases
     // (touchevents, scrollevents...).
     // They're exectuted in a requestAnimationFrame block and are protected


### PR DESCRIPTION
r? @etiennesegonzac 

Hey etienne! I've noticed that we haven't getter and setter for naive property so the web components crash when trying to attach its behavior without setting a scheduler.
