### PR TITLE
Remove version from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "dom-scheduler",
-  "version": "1.0.0",
   "homepage": "https://github.com/etiennesegonzac/dom-scheduler",
   "authors": [
     "Etienne Segonzac <etienne@segonzac.info>"


### PR DESCRIPTION
Apparently Bower just determines versions from Git tags, so we don't need this anymore. I'll gradually remove this from our other component repos too.
